### PR TITLE
fix: configure TypeScript ESM imports for Docker container

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "server.ts",
   "scripts": {
-    "start": "ts-node src/server.ts",
+    "start": "node --loader ts-node/esm src/server.ts",
     "build": "tsc",
-    "dev": "nodemon --exec ts-node src/server.ts",
-    "create-fixtures": "ts-node src/db/createFixtures.ts",
+    "dev": "nodemon --exec node --loader ts-node/esm src/server.ts",
+    "create-fixtures": "node --loader ts-node/esm src/db/createFixtures.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write ."

--- a/api/src/data/db.ts
+++ b/api/src/data/db.ts
@@ -1,5 +1,5 @@
 import { Pool } from "pg";
-import logger from "../middlewares/logger";
+import logger from "../middlewares/logger.js";
 
 export const pool = new Pool({
   user: process.env.DB_USER,

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -2,9 +2,9 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-import app from "./app";
-import { connectDB, closeDB } from "./data/db";
-import logger from "./middlewares/logger";
+import app from "./app.js";
+import { connectDB, closeDB } from "./data/db.js";
+import logger from "./middlewares/logger.js";
 
 // Fonction principale pour démarrer le serveur
 const startServer = async (): Promise<void> => {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -7,8 +7,8 @@
 
     // Environment Settings
     // See also https://aka.ms/tsconfig/module
-    "module": "commonjs",
-    "target": "esnext",
+    "module": "ESNext",
+    "target": "ESNext",
     // For nodejs:
     // "lib": ["esnext"],
     "types": ["node"],
@@ -40,7 +40,7 @@
     // "moduleDetection": "force",
     // "skipLibCheck": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
- Update tsconfig.json to use ESNext modules with bundler resolution
- Add .js extension to local imports (TypeScript ESM requirement)
- Configure ts-node/esm loader in npm scripts for proper module resolution
- Fix module import errors preventing API container from starting

This resolves the "Cannot find module" error when running the API in Docker with "type": "module" in package.json.

## 🎯 Objectif
Description de ce que fait cette PR

## 🔄 Changements
- Changement 1
- Changement 2

## ✅ Tests
- [ ] Tests unitaires passent
- [ ] Tests d'intégration passent
- [ ] Testé manuellement

## 📝 Notes de Review
Points spécifiques à vérifier lors de la review

## 🔗 Issue Liée
Closes #[numéro]
