### PR TITLE
fix: fix connexion db deploy back render

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,4 +21,6 @@ COPY . .
 EXPOSE 3000
 
 # Étape 8 : Commande pour démarrer le serveur
-CMD ["npm", "run", "start"]
+# CMD ["npm", "run", "start"]
+CMD ["sh", "-c", "npx prisma migrate deploy && npx prisma db seed && npm run start"]
+


### PR DESCRIPTION
correction : 
deploy render ok 
mais db semble vide. 
Test => ajout commande dans dockerfile : CMD ["sh", "-c", "npx prisma migrate deploy && npx prisma db seed && npm run start"] - afin de remplir la bdd
