### PR TITLE
fix: test v2 correctif deploy db back render

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,5 +22,4 @@ EXPOSE 3000
 
 # Étape 8 : Commande pour démarrer le serveur
 # CMD ["npm", "run", "start"]
-CMD ["sh", "-c", "npx prisma migrate deploy && npx prisma db seed && npm run start"]
-
+CMD ["sh", "-c", "npx prisma generate && npx prisma migrate deploy && npx prisma db seed && npm run start"]


### PR DESCRIPTION
test v2 correctif dockerfile 
permet possiblement le deploy du back et de la bdd rempli et non vide
